### PR TITLE
Node webhook fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "stripe-sample-web-elements-card-payment",
-    "version": "1.0.0",
-    "description": "Simple card checkout form",
-    "main": "server.js",
-    "scripts": {
-      "start": "node server/node/server.js",
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "stripe-samples",
-    "license": "ISC",
-    "dependencies": {
-      "body-parser": "^1.19.0",
-      "dotenv": "^8.0.0",
-      "express": "^4.17.1",
-      "stripe": "^7.1.0"
-    }
+  "name": "stripe-sample-web-elements-card-payment",
+  "version": "1.0.0",
+  "description": "Simple card checkout form",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server/node/server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "stripe-samples",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "dotenv": "^8.0.0",
+    "express": "^4.17.1",
+    "stripe": "^7.1.0"
   }
+}

--- a/using-webhooks/client/index.html
+++ b/using-webhooks/client/index.html
@@ -16,7 +16,7 @@
   <body>
     <div class="sr-root">
       <div class="sr-main">
-        <div class="sr-payment-form">
+        <form id="payment-form" class="sr-payment-form">
           <div class="sr-combo-inputs-row">
             <div class="sr-input sr-card-element" id="card-element"></div>
           </div>
@@ -25,7 +25,7 @@
             <div class="spinner hidden" id="spinner"></div>
             <span id="button-text">Pay</span><span id="order-amount"></span>
           </button>
-        </div>
+        </form>
         <div class="sr-result hidden">
           <p>Payment completed<br /></p>
           <pre>

--- a/using-webhooks/client/script.js
+++ b/using-webhooks/client/script.js
@@ -25,8 +25,10 @@ fetch("/create-payment-intent", {
   .then(function({ stripe, card, clientSecret }) {
     document.querySelector("button").disabled = false;
 
-    document.querySelector("#submit").addEventListener("click", function(evt) {
-      evt.preventDefault();
+    // Handle form submission.
+    var form = document.getElementById("payment-form");
+    form.addEventListener("submit", function(event) {
+      event.preventDefault();
       // Initiate payment when the submit button is clicked
       pay(stripe, card, clientSecret);
     });

--- a/using-webhooks/server/node/package.json
+++ b/using-webhooks/server/node/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "stripe-sample-web-card-payment",
+  "name": "stripe-sample-web-elements-card-payment",
   "version": "1.0.0",
-  "description": "How to place a hold on a card",
-  "main": "index.js",
+  "description": "Simple card checkout form",
+  "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "@adreyfus-stripe",
+  "author": "stripe-samples",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",

--- a/using-webhooks/server/node/server.js
+++ b/using-webhooks/server/node/server.js
@@ -57,7 +57,7 @@ app.post("/webhook", async (req, res) => {
   // Check if webhook signing is configured.
   if (process.env.STRIPE_WEBHOOK_SECRET) {
     // Retrieve the event by verifying the signature using the raw body and secret.
-    let event, data, eventType;
+    let event;
     let signature = req.headers["stripe-signature"];
     try {
       event = stripe.webhooks.constructEvent(


### PR DESCRIPTION
* Fix bug in webhook handler.
* Change to form submit to be coherent with examples in docs (https://stripe.com/docs/payments/cards/collecting/web)

@adreyfus-stripe regarding the webhook handler bug, should we maybe change to only allow signed webhooks? Then we can remove the different event data extraction methods. Wdyt?